### PR TITLE
Delete the is_refresh after the cookie has been sent once

### DIFF
--- a/sanic_security/oauth.py
+++ b/sanic_security/oauth.py
@@ -235,6 +235,7 @@ def initialize_oauth(app: Sanic) -> None:
     async def session_middleware(request, response):
         if hasattr(request.ctx, "oauth"):
             if request.ctx.oauth.get("is_refresh"):
+                del request.ctx.oauth["is_refresh"]
                 oauth_encode(response, request.ctx.oauth)
             elif request.ctx.oauth.get("revoked"):
                 response.delete_cookie(f"{config.SESSION_PREFIX}_oauth")


### PR DESCRIPTION
Currently, the refreshed cookie is sent with every request to the client, even though it should only be sent once.